### PR TITLE
Make HistMaker in histogram routine JSON-configurable; improve plotting

### DIFF
--- a/src/physana/algorithm/histmaker.py
+++ b/src/physana/algorithm/histmaker.py
@@ -203,6 +203,7 @@ class HistMaker(BaseAlgorithm):
         self.phsp_fallback: bool = True
 
         # file to cutbook sum weights
+        self.divide_sum_weights: bool = True
         self.sum_weights_file: Optional[str] = None
         self.sum_weights_tool: Optional[SumWeightTool] = None
 
@@ -828,7 +829,7 @@ class HistMaker(BaseAlgorithm):
                         sumW2 = np.zeros(nevent)
 
                         # MC only weights
-                        if not p.is_data:
+                        if not p.is_data and self.divide_sum_weights:
                             # multiply MC xsec and divide by sum weights
                             weights *= xsec_tool(event) / sum_weights_tool(event)
 

--- a/src/physana/backends/__init__.py
+++ b/src/physana/backends/__init__.py
@@ -1,4 +1,4 @@
-from .root import RootBackend
+from .root import RootBackend, RootBatchContext
 from .style import StyleMetadata
 
-__all__ = ['RootBackend', 'StyleMetadata']
+__all__ = ['RootBackend', 'RootBatchContext', 'StyleMetadata']

--- a/src/physana/histo/histo1d.py
+++ b/src/physana/histo/histo1d.py
@@ -27,6 +27,7 @@ class Histogram(HistogramBase):
         "xtitle",
         "ytitle",
         "systematics",
+        "disable_weights",
         "_bins",
         "_observable",
         "_systematics_band",
@@ -64,6 +65,9 @@ class Histogram(HistogramBase):
 
         # storage for systematics bands in nominal histogram
         self._systematics_band: dict = {} if self.systematics else None
+
+        # option for turning of weights when filling
+        self.disable_weights: bool = False
 
         # use for holding the data in from_array
         self._data_array: np.ndarray = None
@@ -345,7 +349,7 @@ class Histogram(HistogramBase):
             digitized = np.digitize(data, bins)
             nbins = len(bins) + 1
             content = np.bincount(digitized, weights=weight, minlength=nbins)
-            if w2 is None:
+            if w2 is None and weight is not None:
                 w2 = weight**2
             sumW2 = np.bincount(digitized, weights=w2, minlength=nbins)
             return content, sumW2
@@ -362,10 +366,13 @@ class Histogram(HistogramBase):
         """
         bins = np.asarray(self.bins)
         data = np.asarray(data)
-        if w is not None:
-            w = np.asarray(w)
-        if w2 is not None:
-            w2 = np.asarray(w2)
+        if self.disable_weights:
+            w, w2 = None, None
+        else:
+            if w is not None:
+                w = np.asarray(w)
+            if w2 is not None:
+                w2 = np.asarray(w2)
         content, sumW2 = self.digitize(data, bins, w, w2)
         if accumulate:
             self._bin_content += content

--- a/src/physana/plotMaker.py
+++ b/src/physana/plotMaker.py
@@ -528,6 +528,7 @@ class PlotMaker(object):
         show_total_syts_only=True,  # show total syst. band only.
         divide_binwidth=True,
         ytitles=None,
+        atlas_label_pos=None,
     ):
         logger.info("preparing canvas.")
         canvas = self.make_canvas()
@@ -600,7 +601,9 @@ class PlotMaker(object):
                 else:
                     logger.warning(f"cannot process type {type(t)}")
 
-        if is_ratio:
+        if atlas_label_pos:
+            label_pos = atlas_label_pos
+        elif is_ratio:
             label_pos = {"x": 0.185, "y": 0.87}
         else:
             label_pos = {"x": 0.185, "y": 0.82}


### PR DESCRIPTION
## Changes

- Made `HistMaker` configurable via the `JSON` setup in the histmaker-json routine.
- Added `divide_sum_weights` option to disable normalization by cross-section and sum of weights.
- Added option to skip weights when filling 1D histograms.
- Refactored the histogram plotting interface.
- Introduced `RootBatchContext` to manage `SetBatch` behavior.
- Fixed `ROOT` histogram caching in `PlotJob` to avoid premature garbage collection.

## Related Commits

- dfc8ade: Make `HistMaker` in `histmaker-json` configurable via `JSON`.
- b26511a: Add `divide_sum_weights` to disable cross-section and sum weights normalization.
- c48bc6b: Add option to skip weights in 1D histogram filling.
- a3a929a: Refactor histogram plotting interface.
- ea43b65: Add `RootBatchContext` to manage `SetBatch` behavior.
- b02c02a: Fix histogram caching in `PlotJob`; code cleanup.