### PR TITLE
Add SQLite-based ntuple metadata database

### DIFF
--- a/src/physana/cli/utility.py
+++ b/src/physana/cli/utility.py
@@ -390,3 +390,15 @@ def check_data(files, match_info):
     tools.check_data_completeness(
         tqdm(list_of_files, leave=False), metadata_type, data_year
     )
+
+
+# =============================================================================
+# Generate ntuple metadata DB
+# =============================================================================
+@cli.command()
+@click.option("--pattern", type=str, required=True, help="pattern to glob files")
+@click.option("--output", type=str, default="metadata.db", help="output name")
+@click.option("--exist-ok/--no-exist-ok", default=False, help="skipping existing file.")
+def generate_metadata_db(pattern, output, exist_ok):
+    ntuple_files = tqdm(glob(pattern))
+    tools.generate_metadata_db(ntuple_files, output, exist_ok)

--- a/src/physana/tools/__init__.py
+++ b/src/physana/tools/__init__.py
@@ -1,5 +1,6 @@
 from .xsec import PMGXsec
 from .file_metadata import FileMetaData
+from .file_db import FileSQLiteDB, generate_metadata_db
 from .data_file_check import check_data_completeness
 from .sum_weights import SumWeightTool, extract_cutbook_sum_weights
 from .skim import SkimConfig
@@ -7,6 +8,8 @@ from .skim import SkimConfig
 __all__ = [
     'PMGXsec',
     'FileMetaData',
+    'FileSQLiteDB',
+    'generate_metadata_db',
     'check_data_completeness',
     'SumWeightTool',
     'extract_cutbook_sum_weights',

--- a/src/physana/tools/data_file_check.py
+++ b/src/physana/tools/data_file_check.py
@@ -49,7 +49,7 @@ def check_data_completeness(
         if lookup not in data_year:
             continue
         nfiles[lookup] += fmd.num_executed_files
-        nevents[lookup] += fmd.num_events
+        nevents[lookup] += fmd.num_input_events
 
     for year, (expected_files, expected_events) in data_year.items():
         nfile_fail = nfiles[year] != expected_files

--- a/src/physana/tools/file_db.py
+++ b/src/physana/tools/file_db.py
@@ -2,6 +2,8 @@ import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, Union
 
+from tqdm import tqdm
+
 from .file_metadata import FileMetaData
 
 
@@ -302,6 +304,6 @@ def generate_metadata_db(ntuple_files, output="metadata.db", max_workers=4):
     # Step 2: sequential DB insertion
     with FileSQLiteDB(output) as db:
         db.conn.execute("BEGIN")
-        for meta in metas:
+        for meta in tqdm(metas):
             db.insert_file(meta, commit=False)
         db.conn.commit()

--- a/src/physana/tools/file_db.py
+++ b/src/physana/tools/file_db.py
@@ -1,0 +1,307 @@
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Optional, Union
+
+from .file_metadata import FileMetaData
+
+
+class FileSQLiteDB:
+    def __init__(self, db_path="ntuple_metadata.db"):
+        self.conn = sqlite3.connect(db_path)
+        self._create_tables()
+        self.exist_ok = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.conn.close()
+
+    def close(self):
+        self.conn.close()
+
+    def _create_tables(self):
+        cur = self.conn.cursor()
+
+        # File metadata
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS file_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                data_type TEXT NOT NULL,
+                campaign TEXT NOT NULL,
+                dataset_id INTEGER NOT NULL,
+                e_tag TEXT NOT NULL,
+                num_executed_files INTEGER NOT NULL,
+                num_input_events INTEGER NOT NULL,
+                reco_tree_entries INTEGER NOT NULL,
+                particle_tree_entries INTEGER NOT NULL,
+                num_trees INTEGER NOT NULL,
+                ab_version INTEGER NOT NULL,
+                tcpt_version INTEGER NOT NULL,
+                vjj_version INTEGER NOT NULL,
+                file_path TEXT NOT NULL UNIQUE
+            )
+        """
+        )
+
+        # CutBookkeeper
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cutbookkeeper (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_id INTEGER NOT NULL,
+                dataset_id INTEGER NOT NULL,
+                run_number INTEGER NOT NULL,
+                syst TEXT NOT NULL,
+                total_events REAL NOT NULL,
+                sum_weights REAL NOT NULL,
+                sum_weights_sq REAL NOT NULL,
+                FOREIGN KEY (file_id) REFERENCES file_metadata(id)
+            )
+        """
+        )
+
+        # Campaign summary: per campaign, dataset, systematics
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS campaign_summary (
+                campaign TEXT NOT NULL,
+                dataset_id INTEGER NOT NULL,
+                syst TEXT NOT NULL,
+                num_executed_files INTEGER NOT NULL,
+                num_input_events INTEGER NOT NULL,
+                total_events REAL NOT NULL,
+                sum_weights REAL NOT NULL,
+                sum_weights_sq REAL NOT NULL,
+                PRIMARY KEY (campaign, dataset_id, syst)
+            )
+        """
+        )
+
+        self.conn.commit()
+
+    def insert_file(self, metadata: FileMetaData, commit: bool = True) -> int:
+        """
+        Insert file metadata and cutbookkeeper into database,
+        and incrementally update the campaign_summary table.
+        """
+        cur = self.conn.cursor()
+
+        # Removing existing file path
+        if not self.remove_file(metadata.file_path, commit=commit):
+            return -1
+
+        # Insert file metadata
+        insert_query = """
+            INSERT INTO file_metadata (
+                data_type, campaign, dataset_id, e_tag,
+                num_executed_files, num_input_events,
+                reco_tree_entries, particle_tree_entries, num_trees,
+                ab_version, tcpt_version, vjj_version,
+                file_path
+            ) VALUES (
+                :data_type, :campaign, :dataset_id, :e_tag,
+                :num_executed_files, :num_input_events,
+                :reco_tree_entries, :particle_tree_entries, :num_trees,
+                :ab_version, :tcpt_version, :vjj_version,
+                :file_path
+            )
+        """
+        insert_values = {
+            "data_type": metadata.data_type,
+            "campaign": metadata.campaign,
+            "dataset_id": metadata.dataset_id,
+            "e_tag": metadata.e_tag,
+            "num_executed_files": metadata.num_executed_files,
+            "num_input_events": metadata.num_input_events,
+            "reco_tree_entries": metadata.reco_tree_entries,
+            "particle_tree_entries": metadata.particle_tree_entries,
+            "num_trees": metadata.num_trees,
+            "ab_version": metadata.ab_version,
+            "tcpt_version": metadata.tcpt_version,
+            "vjj_version": metadata.vjj_version,
+            "file_path": metadata.file_path,
+        }
+        cur.execute(insert_query, insert_values)
+        file_id = cur.lastrowid
+
+        # Insert cutbookkeeper and update summary
+        for (dsid, run_number, syst), weight_info in metadata.cutbookkeeper.items():
+            cur.execute(
+                """
+                INSERT INTO cutbookkeeper (
+                    file_id, dataset_id, run_number, syst,
+                    total_events, sum_weights, sum_weights_sq
+                ) VALUES (
+                    :file_id, :dataset_id, :run_number, :syst,
+                    :total_events, :sum_weights, :sum_weights_sq
+                )
+            """,
+                {
+                    "file_id": file_id,
+                    "dataset_id": dsid,
+                    "run_number": run_number,
+                    "syst": syst,
+                    "total_events": weight_info[0],
+                    "sum_weights": weight_info[1],
+                    "sum_weights_sq": weight_info[2],
+                },
+            )
+
+            # Incrementally update campaign_summary
+            cur.execute(
+                """
+                INSERT INTO campaign_summary (
+                    campaign, dataset_id, syst,
+                    num_executed_files, num_input_events,
+                    total_events, sum_weights, sum_weights_sq
+                ) VALUES (
+                    :campaign, :dataset_id, :syst,
+                    :num_executed_files, :num_input_events,
+                    :total_events, :sum_weights, :sum_weights_sq
+                )
+                ON CONFLICT(campaign, dataset_id, syst) DO UPDATE SET
+                    num_executed_files = num_executed_files + excluded.num_executed_files,
+                    num_input_events = num_input_events + excluded.num_input_events,
+                    total_events = total_events + excluded.total_events,
+                    sum_weights = sum_weights + excluded.sum_weights,
+                    sum_weights_sq = sum_weights_sq + excluded.sum_weights_sq
+            """,
+                {
+                    "campaign": metadata.campaign,
+                    "dataset_id": dsid,
+                    "syst": syst,
+                    "num_executed_files": metadata.num_executed_files,
+                    "num_input_events": metadata.num_input_events,
+                    "total_events": weight_info[0],
+                    "sum_weights": weight_info[1],
+                    "sum_weights_sq": weight_info[2],
+                },
+            )
+
+        if commit:
+            self.conn.commit()
+
+        return file_id
+
+    def remove_file(self, file_path: str, commit: bool = True) -> bool:
+        cur = self.conn.cursor()
+
+        # Get file id and campaign
+        cur.execute(
+            "SELECT id, campaign FROM file_metadata WHERE file_path = ?", (file_path,)
+        )
+        row = cur.fetchone()
+        if not row:
+            return True
+
+        if self.exist_ok:
+            return False
+
+        file_id, campaign = row
+
+        # Get cutbookkeeper entries
+        cur.execute(
+            """
+            SELECT dataset_id, syst, total_events, sum_weights, sum_weights_sq
+            FROM cutbookkeeper
+            WHERE file_id = ?
+        """,
+            (file_id,),
+        )
+        cut_entries = cur.fetchall()
+
+        # Decrement campaign_summary
+        for dsid, syst, total_events, sum_weights, sum_weights_sq in cut_entries:
+            cur.execute(
+                """
+                UPDATE campaign_summary
+                SET total_events = total_events - ?,
+                    sum_weights = sum_weights - ?,
+                    sum_weights_sq = sum_weights_sq - ?
+                WHERE campaign = ? AND dataset_id = ? AND syst = ?
+            """,
+                (total_events, sum_weights, sum_weights_sq, campaign, dsid, syst),
+            )
+
+        # Delete cutbookkeeper entries
+        cur.execute("DELETE FROM cutbookkeeper WHERE file_id = ?", (file_id,))
+
+        # Delete file metadata
+        cur.execute("DELETE FROM file_metadata WHERE id = ?", (file_id,))
+
+        if commit:
+            self.conn.commit()
+
+        return True
+
+    def query_file_metadata(
+        self,
+        filters: Optional[dict[str, Union[Any, list[Any]]]] = None,
+        columns: Optional[list[str]] = None,
+        order_by: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[tuple[Any, ...]]:
+        cur = self.conn.cursor()
+        col_str = ", ".join(columns) if columns else "*"
+        query = f"SELECT {col_str} FROM file_metadata"
+        values: list[Any] = []
+
+        if filters:
+            clauses = []
+            for col, val in filters.items():
+                if isinstance(val, list) and val:  # handle IN queries
+                    placeholders = ",".join("?" for _ in val)
+                    clauses.append(f"{col} IN ({placeholders})")
+                    values.extend(val)
+                elif val is None:
+                    clauses.append(f"{col} IS NULL")
+                else:
+                    clauses.append(f"{col} = ?")
+                    values.append(val)
+            query += " WHERE " + " AND ".join(clauses)
+
+        if order_by:
+            query += f" ORDER BY {order_by}"
+
+        if limit:
+            query += " LIMIT ?"
+            values.append(limit)
+
+        cur.execute(query, values)
+        return cur.fetchall()
+
+    def query_files(
+        self,
+        campaign: str | list[str] | None = None,
+        dataset_ids: int | list[int] | None = None,
+        order_by: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[str]:
+        filters: dict[str, Any] = {}
+        if campaign:
+            filters["campaign"] = campaign
+        if dataset_ids:
+            filters["dataset_id"] = dataset_ids
+
+        rows = self.query_file_metadata(
+            columns=["file_path"],
+            filters=filters,
+            order_by=order_by,
+            limit=limit,
+        )
+        return [row[0] for row in rows]
+
+
+def generate_metadata_db(ntuple_files, output="metadata.db", max_workers=4):
+    # Step 1: parallel metadata extraction
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        metas = list(executor.map(FileMetaData, ntuple_files))
+
+    # Step 2: sequential DB insertion
+    with FileSQLiteDB(output) as db:
+        db.conn.execute("BEGIN")
+        for meta in metas:
+            db.insert_file(meta, commit=False)
+        db.conn.commit()

--- a/src/physana/tools/file_metadata.py
+++ b/src/physana/tools/file_metadata.py
@@ -1,4 +1,12 @@
+from pathlib import Path
+import re
+
+import numpy as np
 import uproot
+
+# Precompile regex patterns once
+VERSION_PATTERN = re.compile(r'\bAB\d+-TCPT\d+-Vjj\d+\b')
+NUMBER_PATTERN = re.compile(r'\d+')
 
 
 class FileMetaData:
@@ -7,7 +15,7 @@ class FileMetaData:
 
     Parameters
     ----------
-    filename : str or uproot.reading.ReadOnlyDirectory
+    ifile : str or uproot.reading.ReadOnlyDirectory
         The path to the ROOT file.
 
     Attributes
@@ -22,8 +30,27 @@ class FileMetaData:
         The e-tag of the file.
     num_executed_files : int
         The number of executed files.
+    num_input_events : int
     num_events : int
         The number of events in the file.
+    cutbookkeeper : dict[tuple[int, int, str], numpy.ndarray]
+        A dictionary where each key is a tuple of (dataset ID, run number, system name)
+        and each value is a numpy array containing the total number of events,
+        the sum of weights, and the sum of squared weights.
+    file_path : str
+        The path to the file.
+    reco_tree_entries : int
+        The number of reco tree entries.
+    particle_tree_entries : int
+        The number of particle tree entries.
+    num_trees : int
+        The number of trees.
+    ab_version : int
+        The version of the AnalysisBase package.
+    tcpt_version : int
+        The version of the TCPT package. master branch is 1
+    vjj_version : int
+        The version of the Vjj package. master branch is 1
     """
 
     __slots__ = (
@@ -32,7 +59,15 @@ class FileMetaData:
         "dataset_id",
         "e_tag",
         "num_executed_files",
-        "num_events",
+        "num_input_events",
+        "file_path",
+        "cutbookkeeper",
+        "reco_tree_entries",
+        "particle_tree_entries",
+        "num_trees",
+        "ab_version",
+        "tcpt_version",
+        "vjj_version",
     )
 
     def __init__(self, ifile: str | uproot.ReadOnlyDirectory) -> None:
@@ -44,12 +79,20 @@ class FileMetaData:
         ifile : str or uproot.reading.ReadOnlyDirectory
             The path to the ROOT file.
         """
-        self.data_type: str = None
-        self.campaign: str = None
-        self.dataset_id: int = None
-        self.e_tag: str = None
-        self.num_executed_files: int = None
-        self.num_events: int = None
+        self.data_type: str = ""
+        self.campaign: str = ""
+        self.dataset_id: int = 0
+        self.e_tag: str = ""
+        self.num_executed_files: int = 0
+        self.num_input_events: int = 0
+        self.file_path: str = ""
+        self.cutbookkeeper: dict = {}
+        self.reco_tree_entries: int = 0
+        self.particle_tree_entries: int = 0
+        self.num_trees: int = 0
+        self.ab_version: int = 0
+        self.tcpt_version: int = 0  # 1 is master branch
+        self.vjj_version: int = 0  # 1 is master branch
 
         if isinstance(ifile, str):
             with uproot.open(ifile) as root_file:
@@ -58,12 +101,64 @@ class FileMetaData:
             self._load_metadata(ifile)
 
     def _load_metadata(self, tfile: uproot.ReadOnlyDirectory) -> None:
-        if 'metadata' not in tfile:
-            raise ValueError(f"{tfile.file_path} does not contain metadata")
-        labels = tfile['metadata'].axis().labels()
+        try:
+            labels = tfile['metadata'].axis().labels()
+        except KeyError as _error:
+            raise KeyError(f"{tfile.file_path} does not contain metadata") from _error
+        self.file_path = str(Path(tfile.file_path).resolve())
         self.data_type = labels[0]
         self.campaign = labels[1]
         self.dataset_id = int(labels[2])
         self.e_tag = labels[3]
         self.num_executed_files = tfile['EventLoop_FileExecuted'].num_entries
-        self.num_events = int(tfile['EventLoop_EventCount'].values()[0])
+
+        # the number of events per algorithm
+        # the first entry is the total number of input events
+        self.num_input_events = int(tfile['EventLoop_EventCount'].values()[0])
+
+        # get reco and particle tree entries
+        if reco_tree := tfile.get("reco"):
+            self.reco_tree_entries = reco_tree.num_entries
+            self.num_trees += 1
+        if particle_tree := tfile.get("particleLevel"):
+            self.particle_tree_entries = particle_tree.num_entries
+            self.num_trees += 1
+
+        # get cutbookkeeper
+        if self.data_type == "data":
+            self.cutbookkeeper[(self.campaign, 0, "NOSYS")] = (
+                self.num_input_events,
+                self.num_input_events,
+                self.num_input_events,
+            )
+        else:
+            # what is "CutBookkeeper_Updated"?
+            cutbook_keepers = (
+                x for x in tfile if "CutBookkeeper" in x and "Updated" not in x
+            )
+            for obj_name in cutbook_keepers:
+                _, dsid, run_number, syst = obj_name.split("_")
+
+                # The systematics is of the form "NOSYS;1"
+                syst = syst.split(";")[0]
+
+                lookup = (int(dsid), int(run_number), syst)
+
+                # The cutbookkeeper is a histogram with 3 bins
+                # bin 0: the total number of events
+                # bin 1: the sum of weights
+                # bin 2: the sum of squared weights
+                cutbookkeeper_histo = tfile[obj_name].values()
+                self.cutbookkeeper[lookup] = (
+                    np.double(cutbookkeeper_histo[0]),
+                    np.double(cutbookkeeper_histo[1]),
+                    np.double(cutbookkeeper_histo[2]),
+                )
+
+        # get package version from file path
+        pkg_versions = VERSION_PATTERN.search(self.file_path)
+        if pkg_versions:
+            versions = NUMBER_PATTERN.findall(pkg_versions.group())
+            self.ab_version = versions[0]
+            self.tcpt_version = versions[1]
+            self.vjj_version = versions[2]


### PR DESCRIPTION
# Summary of Changes

- Implemented new SQLite-based database for managing ntuple metadata.
- Added support for storing extended metadata fields from ROOT ntuple files.
- Refactored logic for handling duplicates during metadata DB creation.
- Fixed variable naming issue affecting duplicate detection and handling.

# Related Commits

- 19460b9: include more metadata info for ntuple ROOT files.
- 6fc38b9: implement new ntuple metadata database in SQLite.
- 297e903: update integration with metadata DB.
- c22892c: add progress bar for metadata generation.
- 2ee3d00: rework logic on handling duplicates when creating metadata DB.
- 497188d: correct variable name.